### PR TITLE
One-line patch which bundles libraries/*.jar to final tracker.jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -79,6 +79,7 @@
 			**/media/,
 			**/tracker/,
             **/opensourcephysics/resources/">
+            <zipgroupfileset dir="libraries" includes="*.jar" />
 		</jar>
 	</target>
 


### PR DESCRIPTION
Otherwise ffmpeg was not recognized.
Closes #1 

Not sure that such bundling is a right solution, but I believe that non-working Tracker is worse in any case :)