### PR TITLE
Revert "Build fixes"

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,13 +6,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="libraries/AppleJavaExtensions.jar"/>
 	<classpathentry kind="lib" path="libraries/QTJava.zip"/>
-	<classpathentry kind="lib" path="libraries/ffmpeg-4.0.jar"/>
-	<classpathentry kind="lib" path="libraries/bridj-0.7-SNAPSHOT.jar"/>
-	<classpathentry kind="lib" path="libraries/xuggle-xuggler.jar"/>
-	<classpathentry kind="lib" path="libraries/xuggle-xuggler-5.4.jar"/>
-	<classpathentry kind="lib" path="libraries/slf4j-api.jar"/>
-	<classpathentry kind="lib" path="libraries/logback-core.jar"/>
-	<classpathentry kind="lib" path="libraries/logback-classic.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/ffmpeg-java"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -14,13 +14,6 @@
 	<path id="bridj.jar" location="libraries/bridj-0.7-SNAPSHOT.jar"/>
 	<path id="apple.jar" location="libraries/AppleJavaExtensions.jar" />
 
-	<path id="slf4j-api.jar" location="libraries/slf4j-api.jar" />
-	<path id="logback-core.jar" location="libraries/logback-core.jar" />
-	<path id="logback-classic.jar" location="libraries/logback-classic.jar" />
-	<path id="xuggle-xuggler-5.4.jar" location="libraries/xuggle-xuggler-5.4.jar" />
-	<path id="xuggle-xuggler.jar" location="libraries/xuggle-xuggler.jar" />
-
-
 	<tstamp>
 		<format property="buildtime.isoformat" pattern="yyyy-MM-dd 'T'HH:mm:ss"/>
 	</tstamp>
@@ -59,12 +52,6 @@
 			<classpath refid="ffmpeg.jar"/>
 			<classpath refid="bridj.jar"/>
 			<classpath refid="apple.jar"/>
-
-			<classpath refid="slf4j-api.jar"/>
-			<classpath refid="logback-core.jar"/>
-			<classpath refid="logback-classic.jar"/>
-			<classpath refid="xuggle-xuggler-5.4.jar"/>
-			<classpath refid="xuggle-xuggler.jar"/>
 		</javac>
 		<copy todir="${classes}/org/opensourcephysics/resources">
 			<fileset dir="${ospsrc}/org/opensourcephysics/resources"/>


### PR DESCRIPTION
Reverts fschuett/osptracker-build#4
It does not make sense to add xuggle. Xuggle was removed because it was difficult to handle and uses
ffmpeg anyway but in an old version.
Xuggle is part of original osptracker, so that can be used instead.